### PR TITLE
fix(composition): use code list label instead of name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>Pogues-BO</artifactId>
 	<packaging>war</packaging>
-	<version>4.1.0-rc5</version>
+	<version>4.1.0-rc6</version>
 	<name>Pogues-BO</name>
 
 	<properties>

--- a/src/main/java/fr/insee/pogues/transforms/visualize/composition/InsertCodeLists.java
+++ b/src/main/java/fr/insee/pogues/transforms/visualize/composition/InsertCodeLists.java
@@ -15,12 +15,12 @@ class InsertCodeLists implements CompositionStep {
 
     /** Host questionnaire. */
     private Questionnaire questionnaire;
-    /** Host questionnaire code list names. */
-    private final Set<String> codeListNames = new HashSet<>();
+    /** Host questionnaire code list labels. */
+    private final Set<String> codeListLabels = new HashSet<>();
 
     /**
      * Insert code lists of the referenced questionnaire in the referencing questionnaire.
-     * If a code list of the referenced questionnaire has the same name asa list in the referencing questionnaire,
+     * If a code list of the referenced questionnaire has the same label as a list in the referencing questionnaire,
      * the code list is not added.
      * @param questionnaire Referencing questionnaire.
      * @param referencedQuestionnaire Referenced questionnaire.
@@ -39,12 +39,12 @@ class InsertCodeLists implements CompositionStep {
                 questionnaire.setCodeLists(new CodeLists());
             //
             refCodeLists.getCodeList().forEach(codeList -> {
-                if (! codeListNames.contains(codeList.getName()))
+                if (! codeListLabels.contains(codeList.getLabel()))
                     questionnaire.getCodeLists().getCodeList().add(codeList);
                 else
-                    log.info("Code list with name '{}' is already in host questionnaire '{}', " +
+                    log.info("Code list with label '{}' is already in host questionnaire '{}', " +
                             "so it has not been inserted from reference '{}'",
-                            codeList.getName(), questionnaire.getId(), referencedQuestionnaire.getId());
+                            codeList.getLabel(), questionnaire.getId(), referencedQuestionnaire.getId());
             });
             log.info("Code lists from '{}' inserted in '{}'", referencedQuestionnaire.getId(), questionnaire.getId());
         } else {
@@ -54,7 +54,7 @@ class InsertCodeLists implements CompositionStep {
 
     private void hostCodeLists() {
         if (questionnaire.getCodeLists() != null)
-            questionnaire.getCodeLists().getCodeList().forEach(codeList -> codeListNames.add(codeList.getName()));
+            questionnaire.getCodeLists().getCodeList().forEach(codeList -> codeListLabels.add(codeList.getLabel()));
     }
 
 }

--- a/src/test/java/fr/insee/pogues/transforms/visualize/composition/InsertCodeListsTest.java
+++ b/src/test/java/fr/insee/pogues/transforms/visualize/composition/InsertCodeListsTest.java
@@ -38,17 +38,17 @@ class InsertCodeListsTest {
     }
 
     @Test
-    void insertCodeList_differentName() {
+    void insertCodeList_differentLabels() {
         //
         CodeList codeList = new CodeList();
         codeList.setId("codes1");
-        codeList.setName("CODE_LIST_A");
+        codeList.setLabel("CODE_LIST_A");
         questionnaire.setCodeLists(new CodeLists());
         questionnaire.getCodeLists().getCodeList().add(codeList);
         //
         CodeList codeListRef = new CodeList();
         codeListRef.setId("codes11");
-        codeListRef.setName("CODE_LIST_B");
+        codeListRef.setLabel("CODE_LIST_B");
         referenced1.setCodeLists(new CodeLists());
         referenced1.getCodeLists().getCodeList().add(codeListRef);
         //
@@ -61,17 +61,17 @@ class InsertCodeListsTest {
     }
 
     @Test
-    void insertCodeList_sameName() {
+    void insertCodeList_sameLabel() {
         //
         CodeList codeList = new CodeList();
         codeList.setId("codes1");
-        codeList.setName("CODE_LIST_A");
+        codeList.setLabel("CODE_LIST_A");
         questionnaire.setCodeLists(new CodeLists());
         questionnaire.getCodeLists().getCodeList().add(codeList);
         //
         CodeList codeListRef = new CodeList();
         codeListRef.setId("codes11");
-        codeListRef.setName("CODE_LIST_A");
+        codeListRef.setLabel("CODE_LIST_A");
         referenced1.setCodeLists(new CodeLists());
         referenced1.getCodeLists().getCodeList().add(codeListRef);
         //
@@ -81,7 +81,6 @@ class InsertCodeListsTest {
         assertNotNull(questionnaire.getCodeLists());
         assertFalse(questionnaire.getCodeLists().getCodeList().isEmpty());
         assertEquals(1, questionnaire.getCodeLists().getCodeList().size());
-
         assertEquals("codes1", questionnaire.getCodeLists().getCodeList().get(0).getId());
     }
 


### PR DESCRIPTION
The business name of a code list object is actually hold by the `"label"` property (not `"name"`).

See also: #161 
