### PR TITLE
fix: 'Name' property can be null in legacy questionnaires

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>Pogues-BO</artifactId>
 	<packaging>war</packaging>
-	<version>4.2.1</version>
+	<version>4.2.2</version>
 	<name>Pogues-BO</name>
 
 	<properties>

--- a/src/main/java/fr/insee/pogues/persistence/query/QuestionnairesServiceQueryPostgresqlImpl.java
+++ b/src/main/java/fr/insee/pogues/persistence/query/QuestionnairesServiceQueryPostgresqlImpl.java
@@ -153,6 +153,7 @@ public class QuestionnairesServiceQueryPostgresqlImpl implements QuestionnairesS
 						"\"flowLogic\": ', data -> 'flowLogic',', " +
 						"\"formulasLanguage\": ', data -> 'formulasLanguage','}') " +
 						"FROM pogues WHERE data ->> 'owner' = ? " +
+						"AND data -> 'Name' IS NOT NULL " +
 						"AND data -> 'TargetMode' IS NOT NULL " +
 						"AND data -> 'flowLogic' IS NOT NULL " +
 						"AND data -> 'formulasLanguage' IS NOT NULL"


### PR DESCRIPTION
Fix after #166 

Add a `IS NOT NULL` condition on the `'Name'` property in query behind endpoint `/api/persistence/questionnaires/search/meta`,
since old questionnaires may not have this property (prevented user from using certain stamps).
