### PR TITLE
fix(composition): update collected scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>Pogues-BO</artifactId>
 	<packaging>jar</packaging>
-	<version>4.3.1-SNAPSHOT</version>
+	<version>4.3.2-SNAPSHOT</version>
 	<name>Pogues-BO</name>
 
 	<properties>

--- a/src/main/java/fr/insee/pogues/transforms/visualize/composition/UpdateReferencedVariablesScope.java
+++ b/src/main/java/fr/insee/pogues/transforms/visualize/composition/UpdateReferencedVariablesScope.java
@@ -2,7 +2,9 @@ package fr.insee.pogues.transforms.visualize.composition;
 
 import fr.insee.pogues.exception.DeReferencingException;
 import fr.insee.pogues.exception.IllegalIterationException;
-import fr.insee.pogues.model.*;
+import fr.insee.pogues.model.ComponentType;
+import fr.insee.pogues.model.IterationType;
+import fr.insee.pogues.model.Questionnaire;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -112,9 +114,7 @@ class UpdateReferencedVariablesScope implements CompositionStep {
      * @param iterationId Identifier of the iteration that will be the scope of null-scope variables.
      */
     private static void updateVariablesScope(Questionnaire referencedQuestionnaire, String iterationId) {
-        referencedQuestionnaire.getVariables().getVariable().stream()
-                .filter(variableType -> variableType instanceof CalculatedVariableType
-                        || variableType instanceof ExternalVariableType)
+        referencedQuestionnaire.getVariables().getVariable()
                 .forEach(variableType -> {
                     if (variableType.getScope() == null) {
                         variableType.setScope(iterationId);

--- a/src/test/java/fr/insee/pogues/transforms/visualize/composition/UpdateReferencedVariablesScopeTest.java
+++ b/src/test/java/fr/insee/pogues/transforms/visualize/composition/UpdateReferencedVariablesScopeTest.java
@@ -1,0 +1,99 @@
+package fr.insee.pogues.transforms.visualize.composition;
+
+import fr.insee.pogues.exception.DeReferencingException;
+import fr.insee.pogues.model.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class UpdateReferencedVariablesScopeTest {
+
+    @Test
+    void noLoop_nullScopesShouldBeUnchanged() throws DeReferencingException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        //
+        Questionnaire referencedQuestionnaire = new Questionnaire();
+        CollectedVariableType collectedVariableType = new CollectedVariableType();
+        CalculatedVariableType calculatedVariableType = new CalculatedVariableType();
+        ExternalVariableType externalVariableType = new ExternalVariableType();
+        referencedQuestionnaire.setVariables(new Questionnaire.Variables());
+        referencedQuestionnaire.getVariables().getVariable().add(collectedVariableType);
+        referencedQuestionnaire.getVariables().getVariable().add(calculatedVariableType);
+        referencedQuestionnaire.getVariables().getVariable().add(externalVariableType);
+
+        //
+        new UpdateReferencedVariablesScope().apply(questionnaire, referencedQuestionnaire);
+
+        //
+        assertEquals(3, referencedQuestionnaire.getVariables().getVariable().size());
+        referencedQuestionnaire.getVariables().getVariable().forEach(variableType ->
+                assertNull(variableType.getScope()));
+    }
+
+    @Test
+    void noLoop_scopesShouldBeUnchanged() throws DeReferencingException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        //
+        Questionnaire referencedQuestionnaire = new Questionnaire();
+        CollectedVariableType collectedVariableType = new CollectedVariableType();
+        collectedVariableType.setScope("foo-scope");
+        CalculatedVariableType calculatedVariableType = new CalculatedVariableType();
+        calculatedVariableType.setScope("foo-scope");
+        ExternalVariableType externalVariableType = new ExternalVariableType();
+        externalVariableType.setScope("foo-scope");
+        referencedQuestionnaire.setVariables(new Questionnaire.Variables());
+        referencedQuestionnaire.getVariables().getVariable().add(collectedVariableType);
+        referencedQuestionnaire.getVariables().getVariable().add(calculatedVariableType);
+        referencedQuestionnaire.getVariables().getVariable().add(externalVariableType);
+
+        //
+        new UpdateReferencedVariablesScope().apply(questionnaire, referencedQuestionnaire);
+
+        //
+        assertEquals(3, referencedQuestionnaire.getVariables().getVariable().size());
+        referencedQuestionnaire.getVariables().getVariable().forEach(variableType ->
+                assertEquals("foo-scope", variableType.getScope()));
+    }
+
+    @Test
+    void loopInReferencing_scopesShouldBeUpdated() throws DeReferencingException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setIterations(new Questionnaire.Iterations());
+        DynamicIterationType iterationType = new DynamicIterationType();
+        iterationType.setId("iteration-id");
+        iterationType.getMemberReference().add("seq1");
+        iterationType.getMemberReference().add("seq3");
+        questionnaire.getIterations().getIteration().add(iterationType);
+        SequenceType sequenceType1 = new SequenceType();
+        sequenceType1.setId("seq1");
+        SequenceType sequenceType2 = new SequenceType();
+        sequenceType2.setId("ref-id");
+        SequenceType sequenceType3= new SequenceType();
+        sequenceType3.setId("seq3");
+        questionnaire.getChild().add(sequenceType1);
+        questionnaire.getChild().add(sequenceType2);
+        questionnaire.getChild().add(sequenceType3);
+        //
+        Questionnaire referencedQuestionnaire = new Questionnaire();
+        referencedQuestionnaire.setId("ref-id");
+        CollectedVariableType collectedVariableType = new CollectedVariableType();
+        CalculatedVariableType calculatedVariableType = new CalculatedVariableType();
+        ExternalVariableType externalVariableType = new ExternalVariableType();
+        referencedQuestionnaire.setVariables(new Questionnaire.Variables());
+        referencedQuestionnaire.getVariables().getVariable().add(collectedVariableType);
+        referencedQuestionnaire.getVariables().getVariable().add(calculatedVariableType);
+        referencedQuestionnaire.getVariables().getVariable().add(externalVariableType);
+
+        //
+        new UpdateReferencedVariablesScope().apply(questionnaire, referencedQuestionnaire);
+
+        //
+        referencedQuestionnaire.getVariables().getVariable().forEach(variableType ->
+                assertEquals("iteration-id", variableType.getScope()));
+    }
+
+}


### PR DESCRIPTION
## Summary

During the de-refrencing of a referenced questionnaire for the composition feature, scope of "collected" variables were not updated.

## Done

- fix: remove filter on collected variables in the composition step that update variables' scope
- test: add unit tests on this step
