### PR TITLE
fix(composition): scope of collected being in linked loop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>Pogues-BO</artifactId>
 	<packaging>jar</packaging>
-	<version>4.3.2-SNAPSHOT</version>
+	<version>4.3.3-SNAPSHOT</version>
 	<name>Pogues-BO</name>
 
 	<properties>

--- a/src/main/java/fr/insee/pogues/utils/PoguesModelUtils.java
+++ b/src/main/java/fr/insee/pogues/utils/PoguesModelUtils.java
@@ -76,4 +76,44 @@ public class PoguesModelUtils {
         return iterationType.getMemberReference();
     }
 
+    /**
+     * Returns true if the given iteration corresponds to a linked loop.
+     * @param iterationType A Pogues iteration (loop) object.
+     * @return True if the given iteration corresponds to a linked loop.
+     * @throws IllegalIterationException If the iteration object given is not a DynamicIterationType.
+     */
+    public static boolean isLinkedLoop(IterationType iterationType) throws IllegalIterationException {
+        checkIterationInstance(iterationType);
+        return ((DynamicIterationType) iterationType).getIterableReference() != null;
+    }
+
+    /**
+     * The iteration reference of the given iteration.
+     * If the iteration is a "main" loop, this is null.
+     * If it is a linked loop, this is the identifier of the corresponding "main" loop.
+     * @param iterationType A Pogues iteration (loop) object.
+     * @return The iteration reference of the given iteration.
+     * @throws IllegalIterationException If the iteration object given is not a DynamicIterationType.
+     */
+    public static String getLinkedLoopReference(IterationType iterationType) throws IllegalIterationException {
+        checkIterationInstance(iterationType);
+        return ((DynamicIterationType) iterationType).getIterableReference();
+    }
+
+    /**
+     * Safety check due to a flaw in Pogues-Model: abstract class IterationType has only one inheritor that is
+     * DynamicIterationType. Only the DynamicIterationType class has the "iteration reference" property...
+     * Therefore, an iteration object has to be cast to get this property.
+     * This method throws an exception if the cast fails, and explains why.
+     * @param iterationType A Pogues iteration object.
+     * @throws IllegalIterationException If the iteration object given is not a DynamicIterationType.
+     */
+    private static void checkIterationInstance(IterationType iterationType) throws IllegalIterationException {
+        if (! (iterationType instanceof DynamicIterationType)) // (
+            throw new IllegalIterationException(String.format(
+                    "Pogues iteration with id=%s and name=%s is not is of type %s. " +
+                            "Only DynamicIterationType is supported.",
+                    iterationType.getId(), iterationType.getName(), iterationType.getClass().getSimpleName()));
+    }
+
 }

--- a/src/test/java/fr/insee/pogues/transforms/visualize/composition/UpdateReferencedVariablesScopeTest.java
+++ b/src/test/java/fr/insee/pogues/transforms/visualize/composition/UpdateReferencedVariablesScopeTest.java
@@ -96,4 +96,43 @@ class UpdateReferencedVariablesScopeTest {
                 assertEquals("iteration-id", variableType.getScope()));
     }
 
+    @Test
+    void linkedLoopInReferencing_scopeShouldBeEqualToMainLoopId() throws DeReferencingException {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setIterations(new Questionnaire.Iterations());
+        DynamicIterationType iterationType = new DynamicIterationType();
+        iterationType.setId("linked-loop-id");
+        iterationType.setIterableReference("main-loop-id");
+        iterationType.getMemberReference().add("seq1");
+        iterationType.getMemberReference().add("seq3");
+        questionnaire.getIterations().getIteration().add(iterationType);
+        SequenceType sequenceType1 = new SequenceType();
+        sequenceType1.setId("seq1");
+        SequenceType sequenceType2 = new SequenceType();
+        sequenceType2.setId("ref-id");
+        SequenceType sequenceType3= new SequenceType();
+        sequenceType3.setId("seq3");
+        questionnaire.getChild().add(sequenceType1);
+        questionnaire.getChild().add(sequenceType2);
+        questionnaire.getChild().add(sequenceType3);
+        //
+        Questionnaire referencedQuestionnaire = new Questionnaire();
+        referencedQuestionnaire.setId("ref-id");
+        CollectedVariableType collectedVariableType = new CollectedVariableType();
+        CalculatedVariableType calculatedVariableType = new CalculatedVariableType();
+        ExternalVariableType externalVariableType = new ExternalVariableType();
+        referencedQuestionnaire.setVariables(new Questionnaire.Variables());
+        referencedQuestionnaire.getVariables().getVariable().add(collectedVariableType);
+        referencedQuestionnaire.getVariables().getVariable().add(calculatedVariableType);
+        referencedQuestionnaire.getVariables().getVariable().add(externalVariableType);
+
+        //
+        new UpdateReferencedVariablesScope().apply(questionnaire, referencedQuestionnaire);
+
+        //
+        referencedQuestionnaire.getVariables().getVariable().forEach(variableType ->
+                assertEquals("main-loop-id", variableType.getScope()));
+    }
+
 }

--- a/src/test/java/fr/insee/pogues/utils/PoguesModelUtilsTest.java
+++ b/src/test/java/fr/insee/pogues/utils/PoguesModelUtilsTest.java
@@ -7,7 +7,9 @@ import fr.insee.pogues.model.FlowControlType;
 import fr.insee.pogues.model.IterationType;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class PoguesModelUtilsTest {
 
@@ -38,6 +40,52 @@ class PoguesModelUtilsTest {
         iterationType.getMemberReference().add("seq2");
         iterationType.getMemberReference().add("seq3");
         assertThrows(IllegalIterationException.class, () -> PoguesModelUtils.getIterationBounds(iterationType));
+    }
+
+    static class FooIteration extends IterationType {}
+
+    @Test
+    void isLinkedLoop_wrongObject_shouldThrowException() {
+        // Given an unexpected new type of iteration
+        IterationType iterationType = new FooIteration();
+        // When + Then
+        assertThrows(IllegalIterationException.class, () ->
+                PoguesModelUtils.isLinkedLoop(iterationType));
+    }
+
+    @Test
+    void getLinkedLoopReference_wrongObject_shouldThrowException() {
+        // Given an unexpected new type of iteration
+        IterationType iterationType = new FooIteration();
+        // When + Then
+        assertThrows(IllegalIterationException.class, () ->
+                PoguesModelUtils.getLinkedLoopReference(iterationType));
+    }
+
+    @Test
+    void isLinkedLoop_unitTests() throws IllegalIterationException {
+        //
+        DynamicIterationType mainLoop = new DynamicIterationType();
+        mainLoop.setId("main-loop-id");
+        DynamicIterationType linkedLoop = new DynamicIterationType();
+        linkedLoop.setId("linked-loop-id");
+        linkedLoop.setIterableReference("main-loop-id");
+        //
+        assertFalse(PoguesModelUtils.isLinkedLoop(mainLoop));
+        assertTrue(PoguesModelUtils.isLinkedLoop(linkedLoop));
+    }
+
+    @Test
+    void getLinkedLoopReference_unitTests() throws IllegalIterationException {
+        //
+        DynamicIterationType mainLoop = new DynamicIterationType();
+        mainLoop.setId("main-loop-id");
+        DynamicIterationType linkedLoop = new DynamicIterationType();
+        linkedLoop.setId("linked-loop-id");
+        linkedLoop.setIterableReference("main-loop-id");
+        //
+        assertNull(PoguesModelUtils.getLinkedLoopReference(mainLoop));
+        assertEquals("main-loop-id", PoguesModelUtils.getLinkedLoopReference(linkedLoop));
     }
 
 }


### PR DESCRIPTION
When a a variable is collected within a linked loop, its `"scope"` must be the id of the corresponding "main" loop.

This is managed front-side in each questionnaire, but wasn't done correctly done in the composition "de-referencing" step.