### PR TITLE
Fix: code filters deleted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>21</java.version>
 		<final.asset.name>pogues-bo</final.asset.name>
-		<pogues-model.version>1.6.5</pogues-model.version>
+		<pogues-model.version>1.6.6</pogues-model.version>
 		<fop.version>2.10</fop.version>
 		<springdoc-openapi-ui.version>2.8.6</springdoc-openapi-ui.version>
 		<jacoco.version>0.8.12</jacoco.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>Pogues-BO</artifactId>
 	<packaging>jar</packaging>
-	<version>4.12.0</version>
+	<version>4.12.1-SNAPSHOT.0</version>
 	<name>Pogues-Back-Office</name>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>Pogues-BO</artifactId>
 	<packaging>jar</packaging>
-	<version>4.12.1-SNAPSHOT.0</version>
+	<version>4.12.2-SNAPSHOT</version>
 	<name>Pogues-Back-Office</name>
 
 	<properties>

--- a/src/main/java/fr/insee/pogues/service/CodesListService.java
+++ b/src/main/java/fr/insee/pogues/service/CodesListService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -58,15 +59,12 @@ public class CodesListService {
      */
     public List<String> updateOrAddCodeListToQuestionnaire(Questionnaire questionnaire, String idCodesList, CodesList codesList) {
         List<fr.insee.pogues.model.CodeList> codesLists = questionnaire.getCodeLists().getCodeList();
-        CodeList originalCodesList = null;
-        if (!codesLists.isEmpty()) {
-            originalCodesList = codesLists.stream()
-                    .filter(cL -> idCodesList.equals(cL.getId()))
-                    .findFirst()
-                    .orElseThrow();
-        }
+        CodeList originalCodesList = codesLists.stream()
+                .filter(cL -> idCodesList.equals(cL.getId()))
+                .findFirst()
+                .orElse(null);
         boolean created = updateOrAddCodeListDTD(codesLists, idCodesList, codesList);
-        return !created
+        return !created && originalCodesList != null
                 ? updateQuestionAndVariablesAccordingToCodesList(originalCodesList, questionnaire, idCodesList)
                 : null;
     }

--- a/src/main/java/fr/insee/pogues/service/CodesListService.java
+++ b/src/main/java/fr/insee/pogues/service/CodesListService.java
@@ -11,21 +11,18 @@ import fr.insee.pogues.webservice.error.ErrorCode;
 import fr.insee.pogues.webservice.model.dtd.codelists.CodesList;
 import fr.insee.pogues.webservice.model.dtd.codelists.ExtendedCodesList;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static fr.insee.pogues.utils.CodesListConverter.*;
+import static fr.insee.pogues.utils.CodesListConverter.convertFromCodeListDTDtoCodeListModel;
 import static fr.insee.pogues.utils.json.JSONFunctions.jsonStringtoJsonNode;
 import static fr.insee.pogues.utils.model.CodesList.*;
 import static fr.insee.pogues.utils.model.Variables.getNeededCollectedVariablesInQuestionnaire;
-import static fr.insee.pogues.utils.model.question.Common.removeClarificationQuestion;
 import static fr.insee.pogues.utils.model.question.MultipleChoice.updateMultipleChoiceQuestionAccordingToCodeList;
 import static fr.insee.pogues.utils.model.question.Table.updateTableQuestionAccordingToCodeList;
 
@@ -34,12 +31,11 @@ import static fr.insee.pogues.utils.model.question.Table.updateTableQuestionAcco
 public class CodesListService {
     private final QuestionnairesService questionnairesService;
 
-    public CodesListService(QuestionnairesService questionnairesService){
+    public CodesListService(QuestionnairesService questionnairesService) {
         this.questionnairesService = questionnairesService;
     }
 
     /**
-     *
      * @param questionnaireId
      * @param idCodesList
      * @param codesList
@@ -52,8 +48,8 @@ public class CodesListService {
         updateQuestionnaireInDataBase(questionnaire);
         return updatedQuestionIds;
     }
+
     /**
-     *
      * @param questionnaire
      * @param idCodesList
      * @param codesList
@@ -62,9 +58,16 @@ public class CodesListService {
      */
     public List<String> updateOrAddCodeListToQuestionnaire(Questionnaire questionnaire, String idCodesList, CodesList codesList) {
         List<fr.insee.pogues.model.CodeList> codesLists = questionnaire.getCodeLists().getCodeList();
+        CodeList originalCodesList = null;
+        if (!codesLists.isEmpty()) {
+            originalCodesList = codesLists.stream()
+                    .filter(cL -> idCodesList.equals(cL.getId()))
+                    .findFirst()
+                    .orElseThrow();
+        }
         boolean created = updateOrAddCodeListDTD(codesLists, idCodesList, codesList);
         return !created
-                ? updateQuestionAndVariablesAccordingToCodesList(questionnaire, idCodesList)
+                ? updateQuestionAndVariablesAccordingToCodesList(originalCodesList, questionnaire, idCodesList)
                 : null;
     }
 
@@ -76,7 +79,7 @@ public class CodesListService {
 
     public void deleteCodeListOfQuestionnaire(Questionnaire questionnaire, String codesListId) throws CodesListException {
         List<String> questionsName = getListOfQuestionNameWhereCodesListIsUsed(questionnaire, codesListId);
-        if(!questionsName.isEmpty()){
+        if (!questionsName.isEmpty()) {
             throw new CodesListException(400, ErrorCode.CODE_LIST_RELATED_QUESTIONS_NAME, String.format("CodesList with id %s is required.", codesListId), null, questionsName);
 
         }
@@ -95,14 +98,13 @@ public class CodesListService {
     }
 
     /**
-     *
      * @param existingCodeLists
      * @param idCodesList
      * @param codesListDtdToUpdate
      * @return true if new codeList is created
      */
     boolean updateOrAddCodeListDTD(List<CodeList> existingCodeLists, String idCodesList, CodesList codesListDtdToUpdate) {
-        if(existingCodeLists.stream().noneMatch(codeList -> Objects.equals(idCodesList, codeList.getId()))){
+        if (existingCodeLists.stream().noneMatch(codeList -> Objects.equals(idCodesList, codeList.getId()))) {
             addCodeListDTD(existingCodeLists, codesListDtdToUpdate);
             return true;
         }
@@ -116,34 +118,42 @@ public class CodesListService {
     }
 
 
-    void addCodeListDTD(List<CodeList> existingCodeLists, CodesList codesListDtdToAdd){
+    void addCodeListDTD(List<CodeList> existingCodeLists, CodesList codesListDtdToAdd) {
         existingCodeLists.add(convertFromCodeListDTDtoCodeListModel(codesListDtdToAdd));
     }
 
     void removeCodeListDTD(List<CodeList> existingCodeLists, String id) throws CodesListException {
         boolean deleted = existingCodeLists.removeIf(codeList -> id.equals(codeList.getId()));
-        if(!deleted) throw new CodesListException(404, ErrorCode.CODE_LIST_NOT_FOUND, "Not found", String.format("CodesList with id %s doesn't exist in questionnaire", id),null);
+        if (!deleted)
+            throw new CodesListException(404, ErrorCode.CODE_LIST_NOT_FOUND, "Not found", String.format("CodesList with id %s doesn't exist in questionnaire", id), null);
     }
 
-    List<String> updateQuestionAndVariablesAccordingToCodesList(Questionnaire questionnaire, String updatedCodeListId){
+    List<String> updateQuestionAndVariablesAccordingToCodesList(CodeList originalCodesList, Questionnaire questionnaire, String updatedCodeListId) {
         // Retrieve updatedCodeList in questionnaire
-        CodeList codeList = questionnaire.getCodeLists().getCodeList().stream().filter(cL -> updatedCodeListId.equals(cL.getId())).findFirst().get();
+        CodeList codeList = questionnaire.getCodeLists().getCodeList().stream()
+                .filter(cL -> updatedCodeListId.equals(cL.getId()))
+                .findFirst()
+                .orElseThrow();
         // Just retrieve MULTIPLE_CHOICE and TABLE questions
         List<QuestionType> questionsToModify = getListOfQuestionWhereCodesListIsUsed(questionnaire, updatedCodeListId);
         // Clear Clarification question for concerned question
         questionsToModify.forEach(Common::removeClarificationQuestion);
         // Clear CodeList filters for concerned question
-        questionsToModify.forEach(Common::removeCodeListFilters);
+        if (!isSameCodeList(originalCodesList, codeList)) {
+            questionsToModify.forEach(Common::removeCodeListFilters);
+        }
         // modify Multiple and Table question and get there new Variables
         List<QuestionType> multipleAndTableQuestion = questionsToModify.stream()
                 .filter(questionType -> {
                     QuestionTypeEnum questionTypeEnum = questionType.getQuestionType();
-                    return QuestionTypeEnum.MULTIPLE_CHOICE.equals(questionTypeEnum) || QuestionTypeEnum.TABLE.equals(questionTypeEnum);})
+                    return QuestionTypeEnum.MULTIPLE_CHOICE.equals(questionTypeEnum) || QuestionTypeEnum.TABLE.equals(questionTypeEnum);
+                })
                 .toList();
         List<VariableType> variables = multipleAndTableQuestion.stream()
                 .map(questionType -> {
                     QuestionTypeEnum questionTypeEnum = questionType.getQuestionType();
-                    if(QuestionTypeEnum.MULTIPLE_CHOICE.equals(questionTypeEnum)) return updateMultipleChoiceQuestionAccordingToCodeList(questionType, codeList, questionnaire.getCodeLists().getCodeList());
+                    if (QuestionTypeEnum.MULTIPLE_CHOICE.equals(questionTypeEnum))
+                        return updateMultipleChoiceQuestionAccordingToCodeList(questionType, codeList, questionnaire.getCodeLists().getCodeList());
                     return updateTableQuestionAccordingToCodeList(questionType, codeList, questionnaire.getCodeLists().getCodeList());
                 })
                 .flatMap(Collection::stream)
@@ -158,7 +168,7 @@ public class CodesListService {
         return questionsToModify.stream().map(ComponentType::getId).toList();
     }
 
-    private <T,G> void replaceElementInListAccordingCondition(List<T> elements, Predicate<T> conditionFunction, G newElement, Function<G,T> factory){
+    private <T, G> void replaceElementInListAccordingCondition(List<T> elements, Predicate<T> conditionFunction, G newElement, Function<G, T> factory) {
         for (int i = 0; i < elements.size(); i++) {
             T element = elements.get(i);
             if (conditionFunction.test(element)) {
@@ -179,5 +189,33 @@ public class CodesListService {
     public List<ExtendedCodesList> getCodesListsDTDWithId(String questionnaireId) throws Exception {
         Questionnaire questionnaire = retrieveQuestionnaireWithId(questionnaireId);
         return getCodesListsDTD(questionnaire);
+    }
+
+    /**
+     * Compares two {@code CodeList} objects to determine if they contain
+     * the same root codes (i.e., codes with no parent).
+     * <p>
+     * A root code is identified by an empty parent ({@code getParent().isEmpty()}).
+     * The comparison is based solely on the values of the root codes
+     * and considers the order in which they appear.
+     * </p>
+     *
+     * @param original the reference {@code CodeList}
+     * @param actual the {@code CodeList} to compare
+     * @return {@code true} if both lists contain exactly the same root code values
+     *         in the same order; {@code false} otherwise
+     */
+    public static boolean isSameCodeList(CodeList original, CodeList actual) {
+        List<String> originalCodes = original.getCode().stream()
+                .filter(codeType -> codeType.getParent().isEmpty())
+                .map(CodeType::getValue)
+                .toList();
+
+        List<String> actualCodes = actual.getCode().stream()
+                .filter(codeType -> codeType.getParent().isEmpty())
+                .map(CodeType::getValue)
+                .toList();
+
+        return originalCodes.equals(actualCodes);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -111,9 +111,9 @@ spring:
     defaultSchema: public
     change-log: classpath:db/master.xml
   datasource:
-    url: jdbc:postgresql://localhost:53941/pogues
-    username: pogues
-    password: pogues
+    url:
+    username:
+    password:
     table: pogues
     hikari.maximumPoolSize: 5
   banner:

--- a/src/test/java/fr/insee/pogues/service/CodesListServiceTest.java
+++ b/src/test/java/fr/insee/pogues/service/CodesListServiceTest.java
@@ -292,6 +292,23 @@ class CodesListServiceTest {
     }
 
     @Test
+    @DisplayName("Should add a new CodeList when it does not exist yet")
+    void shouldCreateNewCodeList() throws Exception {
+        Questionnaire questionnaire = loadQuestionnaireFromResources("service/complexTableWithCodesLists.json");
+        String newCodeListId = "new-code-list";
+        assertThat(questionnaire.getCodeLists().getCodeList())
+                .noneMatch(codeList -> newCodeListId.equals(codeList.getId()));
+        CodesList newCodesList = new CodesList(newCodeListId, "new-sauces", List.of(
+                new Code("1", "BBQ", null),
+                new Code("2", "Curry", null)
+        ));
+        List<String> result = codesListService.updateOrAddCodeListToQuestionnaire(questionnaire, newCodeListId, newCodesList);
+        assertThat(questionnaire.getCodeLists().getCodeList())
+                .anyMatch(codeList -> newCodeListId.equals(codeList.getId()));
+        assertThat(result).isNull();
+    }
+
+    @Test
     @DisplayName("Should get right CodeListDTD from questionnaire")
     void shouldGetRightCodesListsFromQuestionnaire() throws Exception {
         Questionnaire questionnaire = loadQuestionnaireFromResources("service/complexTableWithCodesLists.json");

--- a/src/test/java/fr/insee/pogues/service/CodesListServiceTest.java
+++ b/src/test/java/fr/insee/pogues/service/CodesListServiceTest.java
@@ -229,22 +229,43 @@ class CodesListServiceTest {
     }
 
     @Test
-    @DisplayName("Should remove codeList filters after update code list")
+    @DisplayName("CodeList filters should be removed after updating the CodeList because it has changed")
     void shouldRemoveCodeListFilters() throws Exception {
         Questionnaire questionnaire = loadQuestionnaireFromResources("service/complexTableWithCodesLists.json");
         String codesListIdToUpdate = "m7c6apvz";
         String questionIdWithCodeListFilters = "m8hd7kt3";
         QuestionType question = findQuestionWithId(questionnaire, questionIdWithCodeListFilters);
         assertThat(question.getCodeFilters()).hasSize(1);
-        codesListService.updateOrAddCodeListToQuestionnaire(questionnaire, codesListIdToUpdate,
-                new CodesList("id","sauce",List.of(
-                        new Code("1","Mayonnaise",null),
-                        new Code("2","Ketchup",null),
-                        new Code("3","Moutarde",null),
-                        new Code("4","Andalouse ",null),
-                        new Code("5","Poivre ",null)
-                )));
+
+        CodesList updatedCodeList = new CodesList("id", "sauce", List.of(
+                new Code("1", "Mayonnaise", null),
+                new Code("2", "Ketchup", null),
+                new Code("3", "Moutarde", null),
+                new Code("4", "Andalouse", null),
+                new Code("5", "Poivre", null)
+        ));
+
+        codesListService.updateOrAddCodeListToQuestionnaire(questionnaire, codesListIdToUpdate, updatedCodeList);
         assertThat(question.getCodeFilters()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("CodeList filters should not be removed after updating the CodeList because it hasn't changed")
+    void shouldRemoveCodeListFilters2() throws Exception {
+        Questionnaire questionnaire = loadQuestionnaireFromResources("service/complexTableWithCodesLists.json");
+        String codesListIdToUpdate = "m7c6apvz";
+        String questionIdWithCodeListFilters = "m8hd7kt3";
+        QuestionType question = findQuestionWithId(questionnaire, questionIdWithCodeListFilters);
+        assertThat(question.getCodeFilters()).hasSize(1);
+
+        CodesList updatedCodeList = new CodesList("id", "sauce", List.of(
+                new Code("1", "Mayonnaise", null),
+                new Code("3", "Ketchup", null),
+                new Code("4", "Moutarde", null)
+        ));
+
+        codesListService.updateOrAddCodeListToQuestionnaire(questionnaire, codesListIdToUpdate, updatedCodeList);
+        assertThat(question.getCodeFilters()).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
- **Problème posé au départ :** si on ne fait qu'éditer une modalité, tous les filtres sont supprimés...
- **Alternative proposée :** on ne supprime ces filtres que si la structure change.

Par **structure**, on entend _"avoir le même nombre de modalités avec des values similaires"_. Les labels peuvent être différents.
L'ordre doit également être le même, et on ne s'occupe pas des "parents" dans la hiérarchie. 

Des tests ont été ajoutés ainsi que de la javadoc.

