### PR TITLE
fix: codes filters deletion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>Pogues-BO</artifactId>
 	<packaging>jar</packaging>
-	<version>4.14.1</version>
+	<version>4.14.2-SNAPSHOT.0</version>
 	<name>Pogues-Back-Office</name>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>Pogues-BO</artifactId>
 	<packaging>jar</packaging>
-	<version>4.14.2-SNAPSHOT.0</version>
+	<version>4.14.2</version>
 	<name>Pogues-Back-Office</name>
 
 	<properties>

--- a/src/main/java/fr/insee/pogues/utils/model/question/Common.java
+++ b/src/main/java/fr/insee/pogues/utils/model/question/Common.java
@@ -87,7 +87,8 @@ public class Common {
         question.getFlowControl().removeIf(flowControl -> FlowControlTypeEnum.CLARIFICATION.equals(flowControl.getFlowControlType()));
     }
 
-    public static void removeCodeListFilters(QuestionType question){
-        question.getCodeFilters().clear();
+    public static void removeCodeListFilters(QuestionType question, CodeList updatedCodeList){
+        List<String> codesId = updatedCodeList.getCode().stream().map(CodeType::getValue).toList();
+        question.getCodeFilters().removeIf(codeFilter -> !codesId.contains(codeFilter.getCodeValue()));
     }
 }

--- a/src/test/java/fr/insee/pogues/service/CodesListServiceTest.java
+++ b/src/test/java/fr/insee/pogues/service/CodesListServiceTest.java
@@ -229,13 +229,35 @@ class CodesListServiceTest {
     }
 
     @Test
-    @DisplayName("CodeList filters should be removed after updating the CodeList because it has changed")
+    @DisplayName("CodeList filters should be remove because '4' codeValue is removed after updating")
     void shouldRemoveCodeListFilters() throws Exception {
         Questionnaire questionnaire = loadQuestionnaireFromResources("service/complexTableWithCodesLists.json");
         String codesListIdToUpdate = "m7c6apvz";
         String questionIdWithCodeListFilters = "m8hd7kt3";
         QuestionType question = findQuestionWithId(questionnaire, questionIdWithCodeListFilters);
         assertThat(question.getCodeFilters()).hasSize(1);
+        assertEquals("4",question.getCodeFilters().getFirst().getCodeValue());
+
+        CodesList updatedCodeList = new CodesList("id", "sauce", List.of(
+                new Code("1", "Mayonnaise", null),
+                new Code("2", "Ketchup", null),
+                new Code("3", "Moutarde", null),
+                new Code("3bis", "Poivre", null)
+        ));
+
+        codesListService.updateOrAddCodeListToQuestionnaire(questionnaire, codesListIdToUpdate, updatedCodeList);
+        assertThat(question.getCodeFilters()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("CodeList filters should be conserved because '4' code still exist after updating (adding element and change label value)")
+    void shouldNotRemoveCodeListFilters() throws Exception {
+        Questionnaire questionnaire = loadQuestionnaireFromResources("service/complexTableWithCodesLists.json");
+        String codesListIdToUpdate = "m7c6apvz";
+        String questionIdWithCodeListFilters = "m8hd7kt3";
+        QuestionType question = findQuestionWithId(questionnaire, questionIdWithCodeListFilters);
+        assertThat(question.getCodeFilters()).hasSize(1);
+        assertEquals("4",question.getCodeFilters().getFirst().getCodeValue());
 
         CodesList updatedCodeList = new CodesList("id", "sauce", List.of(
                 new Code("1", "Mayonnaise", null),
@@ -246,7 +268,8 @@ class CodesListServiceTest {
         ));
 
         codesListService.updateOrAddCodeListToQuestionnaire(questionnaire, codesListIdToUpdate, updatedCodeList);
-        assertThat(question.getCodeFilters()).isEmpty();
+        assertThat(question.getCodeFilters()).hasSize(1);
+        assertEquals("4",question.getCodeFilters().getFirst().getCodeValue());
     }
 
     @Test


### PR DESCRIPTION
Désormais on ne supprime plus systématiquement les filtres sur les codes de modalités, on ne les supprime que si le code de la modalité n'existe plus dans la liste de code mise à jour.