### PR TITLE
Feat: only one please specify max

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>fr.insee</groupId>
 	<artifactId>Pogues-BO</artifactId>
 	<packaging>jar</packaging>
-	<version>4.18.1</version>
+	<version>4.20.0-SNAPSHOT</version>
 	<name>Pogues-Back-Office</name>
 
 	<properties>

--- a/src/main/java/fr/insee/pogues/service/ModelCleaningService.java
+++ b/src/main/java/fr/insee/pogues/service/ModelCleaningService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import fr.insee.pogues.model.*;
 import fr.insee.pogues.utils.PoguesDeserializer;
 import fr.insee.pogues.utils.PoguesSerializer;
+import fr.insee.pogues.utils.model.cleaner.ClarificationCleaner;
 import fr.insee.pogues.utils.model.cleaner.ControlCriticityCleaner;
 import fr.insee.pogues.utils.model.cleaner.ModelCleaner;
 import fr.insee.pogues.utils.model.cleaner.TableDimensionCleaner;
@@ -31,7 +32,8 @@ public class ModelCleaningService {
     public void cleanModel(Questionnaire questionnaire) {
         List<ModelCleaner> modelCleaners = List.of(
                 new ControlCriticityCleaner(),
-                new TableDimensionCleaner());
+                new TableDimensionCleaner(),
+                new ClarificationCleaner());
         modelCleaners.forEach(modelCleaner -> modelCleaner.apply(questionnaire));
     }
 }

--- a/src/main/java/fr/insee/pogues/utils/model/cleaner/ClarificationCleaner.java
+++ b/src/main/java/fr/insee/pogues/utils/model/cleaner/ClarificationCleaner.java
@@ -1,0 +1,25 @@
+package fr.insee.pogues.utils.model.cleaner;
+
+import fr.insee.pogues.model.ComponentType;
+import fr.insee.pogues.model.QuestionType;
+import fr.insee.pogues.model.QuestionTypeEnum;
+import fr.insee.pogues.model.Questionnaire;
+
+import static fr.insee.pogues.utils.model.question.Common.limitToSingleClarification;
+
+/**
+ * This cleaner ensures that each question (QCU/QCM) keeps only a single clarification question,
+ * and removes related FlowControls that target removed clarifications.
+ */
+public class ClarificationCleaner implements ModelCleaner {
+
+    @Override
+    public void apply(Questionnaire questionnaire) {singleClarification(questionnaire);}
+
+    private void singleClarification(ComponentType poguesComponent){
+        if(poguesComponent instanceof QuestionType question && (QuestionTypeEnum.MULTIPLE_CHOICE.equals(question.getQuestionType())
+        || QuestionTypeEnum.SINGLE_CHOICE.equals(question.getQuestionType())) ){
+            limitToSingleClarification(question);
+        }
+    }
+}

--- a/src/main/java/fr/insee/pogues/utils/model/question/Common.java
+++ b/src/main/java/fr/insee/pogues/utils/model/question/Common.java
@@ -91,4 +91,20 @@ public class Common {
         List<String> codesId = updatedCodeList.getCode().stream().map(CodeType::getValue).toList();
         question.getCodeFilters().removeIf(codeFilter -> !codesId.contains(codeFilter.getCodeValue()));
     }
+
+    public static void limitToSingleClarification(QuestionType question) {
+        List<QuestionType> clarifications = question.getClarificationQuestion();
+        if (clarifications == null || clarifications.size() <= 1) {
+            return;
+        }
+        QuestionType firstClarification = clarifications.getFirst();
+        question.getClarificationQuestion().clear();
+        question.getClarificationQuestion().add(firstClarification);
+
+        List<String> clarificationIdsToKeep = List.of(firstClarification.getId());
+
+        question.getFlowControl().removeIf(fc ->
+                FlowControlTypeEnum.CLARIFICATION.equals(fc.getFlowControlType())
+                        && !clarificationIdsToKeep.contains(fc.getIfTrue()));
+    }
 }

--- a/src/main/java/fr/insee/pogues/utils/model/question/Common.java
+++ b/src/main/java/fr/insee/pogues/utils/model/question/Common.java
@@ -92,19 +92,34 @@ public class Common {
         question.getCodeFilters().removeIf(codeFilter -> !codesId.contains(codeFilter.getCodeValue()));
     }
 
+    /**
+     * Limits the given question to only one clarification question.
+     * If the question has more than one clarification question, this method retains only the first
+     * clarification and removes all others. It also updates the flow controls of the question to
+     * remove any references to the removed clarifications. Finally, it clears the collected variable
+     * references in the responses of the removed clarification questions to avoid dangling references.
+     *
+     * @param question the QuestionType object to be cleaned, expected to have a list of clarification questions.
+     */
     public static void limitToSingleClarification(QuestionType question) {
         List<QuestionType> clarifications = question.getClarificationQuestion();
+
         if (clarifications == null || clarifications.size() <= 1) {
             return;
         }
         QuestionType firstClarification = clarifications.getFirst();
-        question.getClarificationQuestion().clear();
-        question.getClarificationQuestion().add(firstClarification);
-
-        List<String> clarificationIdsToKeep = List.of(firstClarification.getId());
-
+        List<QuestionType> toRemove = new ArrayList<>(clarifications.subList(1, clarifications.size()));
+        clarifications.clear();
+        clarifications.add(firstClarification);
         question.getFlowControl().removeIf(fc ->
-                FlowControlTypeEnum.CLARIFICATION.equals(fc.getFlowControlType())
-                        && !clarificationIdsToKeep.contains(fc.getIfTrue()));
+                FlowControlTypeEnum.CLARIFICATION.equals(fc.getFlowControlType()) &&
+                        !firstClarification.getId().equals(fc.getIfTrue())
+        );
+        for (QuestionType clarification : toRemove) {
+            for (ResponseType response : clarification.getResponse()) {
+                response.setCollectedVariableReference(null);
+            }
+        }
     }
+
 }

--- a/src/test/java/fr/insee/pogues/utils/model/CommonTest.java
+++ b/src/test/java/fr/insee/pogues/utils/model/CommonTest.java
@@ -1,9 +1,7 @@
 package fr.insee.pogues.utils.model;
 
-import fr.insee.pogues.model.CodeType;
-import fr.insee.pogues.model.DatatypeTypeEnum;
-import fr.insee.pogues.model.MappingType;
-import fr.insee.pogues.model.ResponseType;
+import fr.insee.pogues.model.*;
+import fr.insee.pogues.utils.model.question.Common;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,8 +11,7 @@ import static fr.insee.pogues.utils.ModelCreatorUtils.createResponse;
 import static fr.insee.pogues.utils.ModelCreatorUtils.initFakeCodeType;
 import static fr.insee.pogues.utils.model.question.Common.buildMappingsBasedOnTwoDimensions;
 import static fr.insee.pogues.utils.model.question.Common.buildSimpleMappingForMultipleChoiceQuestion;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class CommonTest {
 
@@ -97,5 +94,72 @@ class CommonTest {
         responses.forEach(response -> {
             assertTrue(mappings.stream().anyMatch(m->response.getId().equals(m.getMappingSource())));
         });
+    }
+
+    @Test
+    void testLimitToSingleClarification() {
+
+        QuestionType question = new QuestionType();
+        question.setQuestionType(QuestionTypeEnum.SINGLE_CHOICE);
+
+        // Clarification 1 - kept
+        QuestionType clarification1 = new QuestionType();
+        clarification1.setId("clarif-1");
+        ResponseType resp1 = new ResponseType();
+        resp1.setId("resp-1");
+        resp1.setCollectedVariableReference("var-1");
+        clarification1.getResponse().add(resp1);
+
+        // Clarification 2 - removed
+        QuestionType clarification2 = new QuestionType();
+        clarification2.setId("clarif-2");
+        ResponseType resp2 = new ResponseType();
+        resp2.setId("resp-2");
+        resp2.setCollectedVariableReference("var-2");
+        clarification2.getResponse().add(resp2);
+
+        // Clarification 3 - removed
+        QuestionType clarification3 = new QuestionType();
+        clarification3.setId("clarif-3");
+        ResponseType resp3 = new ResponseType();
+        resp3.setId("resp-3");
+        resp3.setCollectedVariableReference("var-3");
+        clarification3.getResponse().add(resp3);
+
+        // Add the clarifications to the question
+        question.getClarificationQuestion().addAll(List.of(clarification1, clarification2, clarification3));
+
+        // Add FlowControls
+        FlowControlType fc1 = new FlowControlType();
+        fc1.setFlowControlType(FlowControlTypeEnum.CLARIFICATION);
+        fc1.setIfTrue("clarif-1");
+
+        FlowControlType fc2 = new FlowControlType();
+        fc2.setFlowControlType(FlowControlTypeEnum.CLARIFICATION);
+        fc2.setIfTrue("clarif-2");
+
+        FlowControlType fc3 = new FlowControlType();
+        fc3.setFlowControlType(FlowControlTypeEnum.CLARIFICATION);
+        fc3.setIfTrue("clarif-3");
+
+        question.getFlowControl().addAll(List.of(fc1, fc2, fc3));
+
+        // Call the method
+        Common.limitToSingleClarification(question);
+
+        // Verify: only one clarification remains
+        assertEquals(1, question.getClarificationQuestion().size());
+        assertEquals("clarif-1", question.getClarificationQuestion().getFirst().getId());
+
+        // Verify: clarification 1's variable is retained
+        assertEquals("var-1", question.getClarificationQuestion().getFirst().getResponse().getFirst().getCollectedVariableReference());
+
+        // Verify: remaining FlowControls only reference clarif-1
+        assertEquals(1, question.getFlowControl().size());
+        assertEquals("clarif-1", question.getFlowControl().getFirst().getIfTrue());
+
+        // Verify: removed clarifications have their variable references set to null
+        assertNull(resp2.getCollectedVariableReference(), "Clarif 2 variable should be null");
+        assertNull(resp3.getCollectedVariableReference(), "Clarif 3 variable should be null");
     }
 }


### PR DESCRIPTION
L'objectif étant de n'autoriser qu'une seule demande de clarification dans les QCU/QCM, il est nécessaire, côté back, de clean les précisions (et les variables collectées correspondantes). Un cleaner a donc été ajouté pour les clarifications.

**- Seule la première clarification associée à une question est conservée (les autres sont supprimées).
- Les flowControls (et les références aux variables collectées) associés aux clarifications retirées sont également supprimés.**